### PR TITLE
[Issue#8] Mount /zone-name/home in davrods

### DIFF
--- a/bin/helium
+++ b/bin/helium
@@ -9,8 +9,8 @@ CHRONOS_PROTO=https
 #CHRONOS_PROTO=http
 IRODS_PORT=1247
 IRODS_HOST="data.commonsshare.org"
-IRODS_HOME="/commonsshareZone/home/rods"
-IRODS_CWD="/commonsshareZone/home/rods"
+IRODS_HOME="/commonsshareZone/home"
+IRODS_CWD="/commonsshareZone/home"
 IRODS_USER_NAME="rods"
 IRODS_ZONE_NAME="commonsshareZone"
 

--- a/docker/datacommons-base/davrods-vhost.conf
+++ b/docker/datacommons-base/davrods-vhost.conf
@@ -138,7 +138,7 @@
         # - 'User'      (collection /zone-name/home/logged-in-username)
         # - full-path   (named collection, must be absolute path, starts with /)
         #
-        #DavRodsExposedRoot  User
+        DavRodsExposedRoot  Home
 
         # Size of the buffers used for file transfer to/from the iRODS server.
         #


### PR DESCRIPTION
* Modified `davrods-vhost.conf` to specify mounting iRODS zone home directory.
* Modified default input in `bin/helium`